### PR TITLE
fixed mini_adas configs in single agaent mode

### DIFF
--- a/examples/rust/mini-adas/src/bin/adas_primary.rs
+++ b/examples/rust/mini-adas/src/bin/adas_primary.rs
@@ -106,7 +106,6 @@ mod cfg {
             recorder_ids: vec![],
             worker_assignments: agent_assignments().remove(&AGENT_ID).unwrap(),
             timeout: Duration::from_secs(10),
-            connection_timeout: Duration::from_secs(10),
         }
     }
 }


### PR DESCRIPTION
Hi @artemsheinacn,

Here is a fix to the issue i mentioned here https://github.com/eclipse-score/feo/issues/17#issuecomment-3548345138:~:text=Note%3A%20in%20this%20signalling_direct_mpsc*%20I%20needed%20to%20remove%20connection%20timeout%20parameter%20as%20it%27s%20irrelevant%20in%20this%20mode.%20will%20open%20a%20PR%20for%20it%20shortly
connection timeout config is irrelevant  in this mode **signalling_direct_mpsc** 
Thanks!