### PR TITLE
Add rust-analyzer setup for Bazel and VS Code tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,4 +103,9 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+
+    // Enforce Bazel configuration for rust-analyzer (ignore Cargo)
+    "rust-analyzer.linkedProjects": [
+        "rust-project.json"
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Update rust-analyzer config",
+            "type": "shell",
+            "command": "bazel run @rules_rust//tools/rust_analyzer:gen_rust_project",
+            "problemMatcher": [],
+            "group": "build"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ bazel run //examples/rust/mini-adas:adas_primary
 
 [bazelisk]: https://github.com/bazelbuild/bazelisk
 
+## IDE Setup (rust-analyzer)
+
+Because this project relies exclusively on **Bazel** for Rust, you must generate a `rust-project.json` file for `rust-analyzer` to provide features like code completion and go-to-definition.
+
+Generate the configuration by running:
+```sh
+bazel run @rules_rust//tools/rust_analyzer:gen_rust_project
+```
+
+*Note: If you use VS Code, a build task is included. You can press `Ctrl+Shift+B` (or `Cmd+Shift+B`) and select **Update rust-analyzer config** to regenerate this file anytime you add or modify dependencies in your `BUILD.bazel` files.*
+
 ## Profiling
 
 ### CPU


### PR DESCRIPTION
Added instructions in the `README.md` for generating the `rust-project.json` file required by `rust-analyzer` in a Bazel workflow. Also included a `.vscode/tasks.json` to easily automate this generation and updated `.vscode/settings.json` to explicitly point `rust-analyzer` to the generated Bazel project config, ensuring Cargo does not conflict. 
This will significantly improve the IDE onboarding experience for new developers.
