### PR TITLE
docs: update README build and profiling instructions to use Bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ cd feo
 
 ## Rust setup
 
-You can build the Rust code both with `bazel` and with `cargo`.
-The CI will run both builds and ensure neither one is broken.
+You can build the Rust code with `bazel`.
 
 ### Bazel specific commands
 
@@ -50,7 +49,7 @@ bazel query //...
 Run example rust binary
 
 ```sh
-bazel run //examples/rust/mini-adas:adas_primary
+bazel run //examples/rust/mini-adas:adas_primary_com_iox2_direct_unix
 ```
 
 [bazelisk]: https://github.com/bazelbuild/bazelisk
@@ -70,8 +69,8 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mstange/samply/releases
 Profile:
 
 ```sh
-cargo build --example hello_tracing --profile profiling
-samply record target/profiling/examples/hello_tracing
+bazel build -c opt //examples/rust/mini-adas:adas_primary_com_iox2_direct_unix
+samply record bazel-bin/examples/rust/mini-adas/adas_primary_com_iox2_direct_unix
 # ...
 # <ctrl-c>
 ```
@@ -96,7 +95,8 @@ mv bytehound libbytehound.so $HOME/.cargo/bin
 Record something with bytehound:
 
 ```sh
-LD_PRELOAD=$HOME/.cargo/bin/libbytehound.so target/debug/examples/hello_tracing
+bazel build //examples/rust/mini-adas:adas_primary_com_iox2_direct_unix
+LD_PRELOAD=$HOME/.cargo/bin/libbytehound.so bazel-bin/examples/rust/mini-adas/adas_primary_com_iox2_direct_unix
 # ...
 # <ctrl-c>
 ```


### PR DESCRIPTION
This PR resolves the issue with outdated README documentation by updating the build and profiling instructions to use Bazel instead of Cargo https://github.com/eclipse-score/feo/issues/70.

Since cargo build is no longer supported in this repository, and some previously referenced examples (like hello_tracing) do not have Bazel targets, the documentation has been rewritten to ensure all commands are fully functional with the current build system.

Proposal:

Currently, the documentation instructs users to build and profile using cargo and unsupported targets. This PR updates the workflow as follows:

1. Update Build Instructions: Remove mentions of cargo build in the Rust setup section, pointing users exclusively to bazel.
2. Fix CPU Profiling (Samply): Replace the unsupported hello_tracing example with the working mini-adas target (//examples/rust/mini-adas:adas_primary_com_iox2_direct_unix) and update the binary execution paths to use bazel-bin/.
3. Fix Memory Profiling (Bytehound): Change the LD_PRELOAD recording commands to execute the Bazel-built mini-adas binary instead of the old Cargo target/debug/ paths, and update the expected output .dat filenames in the analysis section.

Thanks!