### PR TITLE
chore(bazel): use a minimal module declaration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-module(
-    name = "score_feo",
-    version = "0.0.0",
-    compatibility_level = 1,
-)
+module(name = "score_feo")
 
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "score_bazel_platforms", version = "0.1.1")


### PR DESCRIPTION
<!-- repo-policy-sync-policy: bazel.minimal-module-declaration -->
<!-- repo-policy-sync-head: ff23aaaf6f71537b0db40a9ee65dde858877fc06 -->

## Policy

**`bazel.minimal-module-declaration`**

Keep the Bazel module declaration limited to its repository-owned name.

## Why this repository?

This policy applies to configuration in `MODULE.bazel`.

## Changes

- `MODULE.bazel`: replace matching text
  - Do not hardcode the module version in Git; the Bazel Registry derives it dynamically when a Git release of the module is made, and `compatibility_level` is deprecated.



---

This pull request is managed by SCORE Repository Policy Sync and may be updated by a later policy run.
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!NOTE]
> This pull request is generated automatically. Review the proposed changes
> before merging.
